### PR TITLE
Make sure use-fixtures trumps pulling from website.

### DIFF
--- a/exe/cob_web_index
+++ b/exe/cob_web_index
@@ -23,10 +23,10 @@ class App
     c.desc "Ingest files into SOLR_URL using the web content traject config"
     c.action do |global_options, options, args|
 
-      if args.empty?
-        CobWebIndex::CLI.pull
-      elsif options["use-fixtures"]
+      if options["use-fixtures"]
         CobWebIndex::CLI.ingest_fixtures
+      elsif args.empty?
+        CobWebIndex::CLI.pull
       else
         CobWebIndex::CLI.ingest(ingest_path: args[0], delete_collection: true)
       end


### PR DESCRIPTION
args.empty? is true for `cob_web_index ingest --use-fixtures` so we
need to make sure it's tested before we test for CobWebIndex::CLI.pull
condition.