### PR TITLE
BL-940 Add forms.json data to the indexer

### DIFF
--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -29,8 +29,8 @@ settings do
   provide "solr_writer.max_skipped", -1
 end
 
-WEBSITE_TYPES = /space|service|policy|collection|/i
-CONTENT_TYPES = /person|event|exhibition|space|service|policy|collection/i
+WEBSITE_TYPES = /space|service|policy|collection|form/i
+CONTENT_TYPES = /person|event|exhibition|space|service|policy|collection|form/i
 
 to_field "id", ->(rec, acc) {
   acc << "#{rec['type']}_#{rec['id']}"

--- a/spec/fixtures/forms.json
+++ b/spec/fixtures/forms.json
@@ -1,0 +1,92 @@
+{
+  "data": [
+    {
+      "id": "missing-book",
+      "type": "form",
+      "attributes": {
+        "label": "Missing Book Search Request",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/missing-book"
+      }
+    },
+    {
+      "id": "recall-book",
+      "type": "form",
+      "attributes": {
+        "label": "Request Recall of Books Already Checked Out",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/recall-book"
+      }
+    },
+    {
+      "id": "hsl-book-reserve",
+      "type": "form",
+      "attributes": {
+        "label": "Request book(s) for reserve-Ginsburg Health Sciences Library",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/hsl-book-reserve"
+      }
+    },
+    {
+      "id": "proxy-account",
+      "type": "form",
+      "attributes": {
+        "label": "Proxy Account",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/proxy-account"
+      }
+    },
+    {
+      "id": "ask-scrc",
+      "type": "form",
+      "attributes": {
+        "label": "Special Collections Research Center: Ask a Question",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/ask-scrc"
+      }
+    },
+    {
+      "id": "data-purchase-grants-application",
+      "type": "form",
+      "attributes": {
+        "label": "Library Data Grants",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/data-purchase-grants-application"
+      }
+    },
+    {
+      "id": "ir",
+      "type": "form",
+      "attributes": {
+        "label": "Incident Report",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/ir"
+      }
+    },
+    {
+      "id": "purchase-request",
+      "type": "form",
+      "attributes": {
+        "label": "Purchase Request",
+        "updated_at": "0000-01-01T00:00:00.000+00:00"
+      },
+      "links": {
+        "self": "https://web.qa.tul-infra.page/forms/purchase-request"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds forms data to the traject indexer file.  It should include type, label, and link. Label and link are already ingested for all JSON data, but form type was added for content_types.