### PR TITLE
Create web_full_description_t solr field

### DIFF
--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -92,6 +92,16 @@ to_field "web_description_display", ->(rec, acc) {
   end
 }, &truncate(100)
 
+
+# make sure the ful index is searchable
+to_field "web_full_description_t", ->(rec, acc) {
+  if rec.dig("attributes", "description")
+    acc << Nokogiri::HTML(rec.dig("attributes", "description")).text
+  end
+}
+
+
+
 #person specific
 to_field "web_job_title_display", extract_json("$.attributes.job_title")
 to_field "web_email_address_display", extract_json("$.attributes.email_address")


### PR DESCRIPTION
web_description_dipslay truncates at 100 characters, and thus much of the content is not searchable. This add a web_full_description_t field so it is searchable but not stored for display, since we are not currently planning to display the full descriptin text via BL.

Relates to https://tulibdev.atlassian.net/browse/MAN-608