### PR TITLE
Do not index records that are not supported.

### DIFF
--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -36,7 +36,7 @@ to_field "id", ->(rec, acc) {
   acc << "#{rec['type']}_#{rec['id']}"
 }
 
-to_field "web_content_type_facet", ->(rec, acc) {
+to_field "web_content_type_facet", ->(rec, acc, context) {
   if rec.fetch("type").match(WEBSITE_TYPES)
     acc << rec.fetch("type")
   end
@@ -56,6 +56,10 @@ to_field "web_content_type_facet", ->(rec, acc) {
 
   if rec.fetch("type") == "finding_aid"
     acc << "Finding Aids"
+  end
+
+  if acc.empty?
+    context.skip!("Skipping unsopported type #{rec.fetch("type")}: #{context.output_hash["id"]}")
   end
 }
 

--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -59,7 +59,7 @@ to_field "web_content_type_facet", ->(rec, acc, context) {
   end
 
   if acc.empty?
-    context.skip!("Skipping unsopported type #{rec.fetch("type")}: #{context.output_hash["id"]}")
+    context.skip!("Skipping unsupported type #{rec.fetch("type")}: #{context.output_hash["id"]}")
   end
 }
 

--- a/spec/cob_web_index_spec.rb
+++ b/spec/cob_web_index_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CobWebIndex do
     end
   end
 
-  context "An unsoported type record is indexed" do
+  context "An unsupported type record is indexed" do
     # keys MUST be strings or an error is thrown.
     let (:record) { {
       "id" => "foo",

--- a/spec/cob_web_index_spec.rb
+++ b/spec/cob_web_index_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CobWebIndex do
     # keys MUST be strings or an error is thrown.
     let (:record) { {
       "id" => "foo",
-      "type" => "unsopported",
+      "type" => "unsupported",
       "attributes" => {
         "job_title" => "worker",
         "email_address" => "foo@helloworld",

--- a/spec/cob_web_index_spec.rb
+++ b/spec/cob_web_index_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe CobWebIndex do
       expect(mapped_record["web_specialties_display"]).to eq([["foo", "bar"]])
     end
   end
+
+  context "An unsoported type record is indexed" do
+    # keys MUST be strings or an error is thrown.
+    let (:record) { {
+      "id" => "foo",
+      "type" => "unsopported",
+      "attributes" => {
+        "job_title" => "worker",
+        "email_address" => "foo@helloworld",
+        "specialties" => [ "foo", "bar" ]
+      }
+    } }
+
+
+    it "skips the record" do
+      expect(mapped_record).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
REF BL-976

Skips records if the type is not known/configured in the indexer
configuration.