### PR TITLE
Failed records should not return code 0

### DIFF
--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -26,7 +26,7 @@ settings do
   provide "solr_writer.commit_on_close", "false"
 
   # set this to be non-negative if threshold should be enforced
-  provide "solr_writer.max_skipped", -1
+  provide "solr_writer.max_skipped", 0
 end
 
 WEBSITE_TYPES = /space|service|policy|collection|form/i


### PR DESCRIPTION
This re-applies the fail on skip doc change.