### PR TITLE
Add basic auth config if environment variables set.

### DIFF
--- a/lib/cob_web_index/indexer_config.rb
+++ b/lib/cob_web_index/indexer_config.rb
@@ -27,6 +27,11 @@ settings do
 
   # set this to be non-negative if threshold should be enforced
   provide "solr_writer.max_skipped", 0
+
+  if ENV["SOLR_AUTH_USER"] && ENV["SOLR_AUTH_PASSWORD"]
+    provide "solr_json_writer.basic_auth_user", ENV["SOLR_AUTH_USER"]
+    provide "solr_json_writer.basic_auth_password", ENV["SOLR_AUTH_PASSWORD"]
+  end
 end
 
 WEBSITE_TYPES = /space|service|policy|collection|form/i


### PR DESCRIPTION
* Our SolrCloud instance is behind basic auth protection so we need to
pass basic auth traject configurations per traject 3.2.0