### PR TITLE
Revert "Pin travis pin to ruby 2.4.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
+  - 2.4
   - 2.5
   - 2.6
 


### PR DESCRIPTION
Reverts tulibraries/cob_web_index#39

Probably better to just upgrade to latest 2.4 or another ruby 2.5, or 2.6, 2.7