### PR TITLE
DEVO-388 Failing DAGS on QA

### DIFF
--- a/lib/cob_web_index.rb
+++ b/lib/cob_web_index.rb
@@ -56,14 +56,12 @@ module CobWebIndex
     end
 
     def self.open_read(url)
+      options = {}
       if ENV["WEB_CONTENT_BASIC_AUTH_USER"] && ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"]
-        user = ENV["WEB_CONTENT_BASIC_AUTH_USER"]
-        password = ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"]
-        uri = URI.open(url, { http_basic_authentication: [user, password], read_timeout: 180 }).read
-      else
-        uri = URI.open(url).read
+        options = { http_basic_authentication: [ENV["WEB_CONTENT_BASIC_AUTH_USER"], ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"]] }
       end
-      uri
+      options[:read_timeout] = ENV["WEB_CONTENT_READ_TIMEOUT"].to_i if ENV["WEB_CONTENT_READ_TIMEOUT"]
+      URI.open(url, options).read
     end
 
     def self.ingest_fixtures(opts = {})

--- a/lib/cob_web_index.rb
+++ b/lib/cob_web_index.rb
@@ -3,6 +3,7 @@
 require "cob_web_index/version"
 require "traject"
 require "httparty"
+require "pry"
 
 module CobWebIndex
   class WebContentError < StandardError
@@ -58,10 +59,11 @@ module CobWebIndex
       if ENV["WEB_CONTENT_BASIC_AUTH_USER"] && ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"]
         user = ENV["WEB_CONTENT_BASIC_AUTH_USER"]
         password = ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"]
-        URI.open(url, http_basic_authentication: [user, password]).read
+        uri = URI.open(url, { http_basic_authentication: [user, password], read_timeout: 180 }).read
       else
-        URI.open(url).read
+        uri = URI.open(url).read
       end
+      uri
     end
 
     def self.ingest_fixtures(opts = {})

--- a/spec/cob_web_index_spec.rb
+++ b/spec/cob_web_index_spec.rb
@@ -72,4 +72,36 @@ RSpec.describe CobWebIndex do
       CobWebIndex::CLI.ingest(ingest_path: null_data_file)
     end
   end
+
+  context "URI open and read options" do
+    let(:uri) { "https://example.com/documents.json" }
+    let(:username) { "user" }
+    let(:password) { "mypassword" }
+    let(:read_timeout) { 12345 }
+
+    before(:each) {
+      ENV.clear
+      allow(URI).to receive_message_chain(:open, :read)
+    }
+
+    it "receives no options" do
+      expect(URI).to receive(:open).with(uri, {})
+      CobWebIndex::CLI.open_read(uri)
+    end
+
+    it "handles authentication options" do
+      ENV["WEB_CONTENT_BASIC_AUTH_USER"] = username
+      ENV["WEB_CONTENT_BASIC_AUTH_PASSWORD"] = password
+
+      expect(URI).to receive(:open).with(uri, { http_basic_authentication: [username, password] })
+      CobWebIndex::CLI.open_read(uri)
+    end
+
+    it "handles read_timeout options" do
+      ENV["WEB_CONTENT_READ_TIMEOUT"] = read_timeout.to_s
+
+      expect(URI).to receive(:open).with(uri, { read_timeout: read_timeout })
+      CobWebIndex::CLI.open_read(uri)
+    end
+  end
 end


### PR DESCRIPTION
On QA, it takes FindingAids 2:32 seconds to respond to a JSON request because of the number of items returned.  This request allows DAG to use a read timeout by setting the WEB_CONTENT_READ_TIMEOUT time in seconds (integer). Suggested value is 180.